### PR TITLE
add the subscription/one-step endpont

### DIFF
--- a/lib/gerencianet/constants.rb
+++ b/lib/gerencianet/constants.rb
@@ -78,6 +78,10 @@ module Gerencianet
           route: "/plan/:id/subscription",
           method: "post"
         },
+        create_subscription_onestep: {
+          route: "/plan/:id/subscription/one-step",
+          method: "post"
+        },
         detail_subscription: {
           route: "/subscription/:id",
           method: "get"


### PR DESCRIPTION
This PR adds the subscription/one-step endpoint.  It can be called like this:

```ruby
client.create_subscription_onestep(body: body, params: params)
```