### PR TITLE
1.2.0 - New api endpoints for efipay.com.br

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.0
+
+- Updated: Changing from gerencianet.com.br to efipay.com.br
+- Updated: http.rb non sticky version
+
 # 1.0.2
 
 - Updated: PixSend example

--- a/gerencianet.gemspec
+++ b/gerencianet.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 0.49.1", ">= 0.49.1"
   spec.add_development_dependency "listen", "~> 3.0.4", ">= 3.0.4"
 
-  spec.add_runtime_dependency "http", "~> 0.9", ">= 0.9.8"
+  spec.add_runtime_dependency "http", ">= 0.9.8"
 end

--- a/lib/gerencianet/constants.rb
+++ b/lib/gerencianet/constants.rb
@@ -3,12 +3,12 @@ module Gerencianet
   module Constants
     URL = {
       DEFAULT: {
-          production: "https://api.gerencianet.com.br/v1",
-          sandbox: "https://sandbox.gerencianet.com.br/v1"
+          production: "https://cobrancas.api.efipay.com.br/v1",
+          sandbox: "https://cobrancas-h.api.efipay.com.br/v1"
       },
       PIX: {
-          production: "https://api-pix.gerencianet.com.br",
-          sandbox: "https://api-pix-h.gerencianet.com.br"
+          production: "https://pix.api.efipay.com.br",
+          sandbox: "https://pix-h.api.efipay.com.br"
       }
     }
 

--- a/lib/gerencianet/version.rb
+++ b/lib/gerencianet/version.rb
@@ -1,4 +1,4 @@
 # :nodoc:
 module Gerencianet
-  VERSION = "1.1.2"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
Since the gerencianet.com.br endpoints are now deprecated, this version now uses efipay.com.br as their replacement.
Removes the fixed version constraint for http.rb (too old).